### PR TITLE
AC: Update searchJira to allow setting startAt and maxResults

### DIFF
--- a/lib/jira.js
+++ b/lib/jira.js
@@ -498,11 +498,14 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
     // ### Takes ###
     //
     // *  searchString: jira query string
-    // *  fields: optional array of desired fields, defaults when null: 
-    //   *  "summary"
-    //   *  "status"
-    //   *  "assignee"
-    //   *  "description" 
+    // *  optional: object containing any of the following properties
+    //   *  startAt: optional index number (default 0)
+    //   *  maxResults: optional max results number (default 50)
+    //   *  fields: optional array of desired fields, defaults when null:
+    //     *  "summary"
+    //     *  "status"
+    //     *  "assignee"
+    //     *  "description"
     // *  callback: for when it's done
     //
     // ### Returns ###
@@ -510,24 +513,27 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
     // *  error: string if there's an error
     // *  issues: array of issues for the user
     //
-    // [Jira Doc](http://docs.atlassian.com/jira/REST/latest/#id296043)
+    // [Jira Doc](http://docs.atlassian.com/jira/REST/latest/#id333082)
     //
-    this.searchJira = function(searchString, fields, callback) {
-
-        
-        if (fields == null) {
-            fields = ["summary", "status", "assignee", "description"];
+    this.searchJira = function(searchString, optional, callback) {
+        // backwards compatibility
+        optional = optional || {};
+        if (Array.isArray(optional)) {
+            optional = { fields: optional };
         }
+
         var options = {
             uri: this.makeUri('/search'),
             method: 'POST',
             json: true,
             body: {
-                jql:searchString,
-                startAt: 0,
-                fields: fields 
+                jql: searchString,
+                startAt: optional.startAt || 0,
+                maxResults: optional.maxResults || 50,
+                fields: optional.fields || ["summary", "status", "assignee", "description"]
             }
         };
+
         this.request(options, function(error, response, body) {
             if (response.statusCode === 400) {
                 callback('Problem with the JQL query');
@@ -561,7 +567,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         var jql = "assignee = " + username;
         var openText = ' AND status in (Open, "In Progress", Reopened)';
         if (open) { jql += openText; }
-        this.searchJira(jql, null, callback);
+        this.searchJira(jql, {}, callback);
     };
 
     // ## Add issue to Jira ##

--- a/spec/jira.spec.coffee
+++ b/spec/jira.spec.coffee
@@ -224,7 +224,7 @@ describe "Node Jira Tests", ->
             statusCode:201, '{"body":"none"}'
         expect(@cb).toHaveBeenCalledWith null, '{"body":"none"}'
 
-    it "Passes a search query to Jira, default fields", ->
+    it "Passes a search query to Jira, default options", ->
         fields = ["summary", "status", "assignee", "description"]
         options =
             uri: makeUrl "search"
@@ -233,9 +233,10 @@ describe "Node Jira Tests", ->
             body:
                 jql: 'aJQLstring'
                 startAt: 0
+                maxResults: 50
                 fields: fields
 
-        @jira.searchJira 'aJQLstring', null, @cb
+        @jira.searchJira 'aJQLstring', {}, @cb
         expect(@jira.request).toHaveBeenCalledWith options, jasmine.any(Function)
 
         # Invalid Project
@@ -251,7 +252,7 @@ describe "Node Jira Tests", ->
             statusCode:200, '{"body":"none"}'
         expect(@cb).toHaveBeenCalledWith null, '{"body":"none"}'
 
-    it "Passes a search query to Jira, non-default fields", ->
+    it "Passes a search query to Jira, non-default options", ->
         fields = ["assignee", "description", "test"]
         options =
             uri: makeUrl "search"
@@ -259,10 +260,11 @@ describe "Node Jira Tests", ->
             json: true
             body:
                 jql: 'aJQLstring'
-                startAt: 0
+                startAt: 200
+                maxResults: 100
                 fields: fields
 
-        @jira.searchJira 'aJQLstring', fields, @cb
+        @jira.searchJira 'aJQLstring', { maxResults: 100, fields: fields, startAt: 200 }, @cb
         expect(@jira.request).toHaveBeenCalledWith options, jasmine.any(Function)
 
     it "Gets a specified User's OPEN Issues", ->
@@ -271,7 +273,7 @@ describe "Node Jira Tests", ->
  Reopened)"
         
         @jira.getUsersIssues 'test', true, @cb
-        expect(@jira.searchJira).toHaveBeenCalledWith expected, null,
+        expect(@jira.searchJira).toHaveBeenCalledWith expected, {},
             jasmine.any(Function)
 
     it "Gets ALL a specified User's Issues", ->
@@ -279,7 +281,7 @@ describe "Node Jira Tests", ->
         expected = "assignee = test"
         
         @jira.getUsersIssues 'test', false, @cb
-        expect(@jira.searchJira).toHaveBeenCalledWith expected, null,
+        expect(@jira.searchJira).toHaveBeenCalledWith expected, {},
             jasmine.any(Function)
 
     it "Deletes an Issue", ->


### PR DESCRIPTION
The searchJira function currently hard codes the startAt or maxResults parameters. This pull request makes these parameters customizable in a backwards compatible way. Tests are updated and green.

``` js
// old usage:
searchJira(query, fields, cb);

// new usage:
searchJira(query, { fields: fields, startAt: 200, maxResults: 50 }, cb);
```
