### PR TITLE
Added error handling to prevent a crash

### DIFF
--- a/lib/jira.js
+++ b/lib/jira.js
@@ -144,6 +144,12 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         };
 
         this.request(options, function(error, response, body) {
+        
+            if (error) {
+                callback(error, null);
+                return;
+            }
+            
             if (response.statusCode === 404) {
                 callback('Invalid issue number.');
                 return;
@@ -178,6 +184,12 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         };
 
         this.request(options, function(error, response, body) {
+           
+            if (error) {
+                callback(error, null);
+                return;
+            }
+          
             if (response.statusCode === 404) {
                 callback('Invalid version.');
                 return;
@@ -190,6 +202,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
 
             body = JSON.parse(body);
             callback(null, body.issuesUnresolvedCount);
+            
         });
     };
 
@@ -213,6 +226,12 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         };
 
         this.request(options, function(error, response, body) {
+
+            if (error) {
+                callback(error, null);
+                return;
+            }
+
             if (response.statusCode === 404) {
                 callback('Invalid project.');
                 return;
@@ -225,6 +244,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
 
             body = JSON.parse(body);
             callback(null, body);
+            
         });
     };
 
@@ -253,6 +273,12 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         };
 
         this.request(options, function(error, response) {
+
+          if (error) {
+              callback(error, null);
+              return;
+          }
+
           if (response.statusCode === 404) {
             callback('Invalid URL');
             return;
@@ -272,6 +298,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
               }
             }
           }
+          
       });
     };
 
@@ -300,6 +327,12 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         };
 
         this.request(options, function(error, response) {
+
+          if (error) {
+              callback(error, null);
+              return;
+          }
+          
           if (response.statusCode === 404) {
             callback('Invalid URL');
             return;
@@ -315,6 +348,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             callback(null, sprints.pop());
             return;
           }
+          
         });
     };
 
@@ -345,6 +379,12 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
       };
 
       this.request(options, function(error, response) {
+
+        if (error) {
+            callback(error, null);
+            return;
+        }
+        
         if( response.statusCode === 404 ) {
           callback('Invalid URL');
           return;
@@ -360,6 +400,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         } else {
           callback('No body');
         }
+        
       });
 
     };
@@ -397,7 +438,14 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         };
 
         logger.log(options.uri);
+        
         this.request(options, function(error, response) {
+
+          if (error) {
+              callback(error, null);
+              return;
+          }
+          
           if (response.statusCode === 404) {
             callback('Invalid URL');
             return;
@@ -452,6 +500,12 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         };
 
         this.request(options, function(error, response) {
+
+            if (error) {
+                callback(error, null);
+                return;
+            }
+
             if (response.statusCode === 404) {
                 callback('Invalid project.');
                 return;
@@ -463,6 +517,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             }
 
             callback(null);
+            
         });
     };
 
@@ -485,6 +540,12 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         };
 
         this.request(options, function(error, response, body) {
+
+            if (error) {
+                callback(error, null);
+                return;
+            }
+
             if (response.statusCode === 404) {
                 callback('Invalid project.');
                 return;
@@ -497,6 +558,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
 
             body = JSON.parse(body);
             callback(null, body);
+            
         });
     };
 
@@ -533,6 +595,12 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             body: version
         };
         this.request(options, function(error, response, body) {
+ 
+            if (error) {
+                callback(error, null);
+                return;
+            }
+ 
             if (response.statusCode === 404) {
                 callback('Version does not exist or the currently authenticated user does not have permission to view it');
                 return;
@@ -549,6 +617,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             }
 
             callback(null, body);
+            
         });
     };
     
@@ -594,6 +663,12 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         };
 
         this.request(options, function(error, response, body) {
+
+            if (error) {
+                callback(error, null);
+                return;
+            }
+
             if (response.statusCode === 400) {
                 callback('Problem with the JQL query');
                 return;
@@ -605,6 +680,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             }
 
             callback(null, body);
+            
         });
     };
     
@@ -650,6 +726,12 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         };
 
         this.request(options, function(error, response, body) {
+
+            if (error) {
+                callback(error, null);
+                return;
+            }
+
             if (response.statusCode === 400) {
                 callback(body);
                 return;
@@ -661,6 +743,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             }
 
             callback(null, body);
+            
         });
     };
 // ## Delete issue to Jira ##
@@ -683,12 +766,19 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         };
 
         this.request(options, function(error, response) {
+
+            if (error) {
+                callback(error, null);
+                return;
+            }
+
             if (response.statusCode === 204) {
                 callback(null, "Success");
                 return;
             }
 
             callback(response.statusCode + ': Error while deleting');
+            
         });
     };
     // ## Update issue in Jira ##
@@ -713,11 +803,19 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         };
 
         this.request(options, function(error, response) {
+
+            if (error) {
+                callback(error, null);
+                return;
+            }
+
             if (response.statusCode === 200) {
                 callback(null, "Success");
                 return;
             }
+            
             callback(response.statusCode + ': Error while updating');
+            
         });
     };
     // ## List Transitions ##
@@ -776,6 +874,12 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         };
 
         this.request(options, function(error, response, body) {
+
+            if (error) {
+                callback(error, null);
+                return;
+            }
+            
             if (response.statusCode === 200) {
                 callback(null, body.transitions);
                 return;
@@ -786,6 +890,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             }
 
             callback(response.statusCode + ': Error while updating');
+            
         });
     };
     // ## Transition issue in Jira ##
@@ -810,11 +915,19 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         };
 
         this.request(options, function(error, response) {
+
+            if (error) {
+                callback(error, null);
+                return;
+            }
+
             if (response.statusCode === 204) {
                 callback(null, "Success");
                 return;
             }
+            
             callback(response.statusCode + ': Error while updating');
+            
         });
     };
     
@@ -849,6 +962,12 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         };
 
         this.request(options, function(error, response, body) {
+
+            if (error) {
+                callback(error, null);
+                return;
+            }
+            
             if (response.statusCode === 200) {
                 callback(null, body);
                 return;
@@ -859,6 +978,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             }
 
             callback(response.statusCode + ': Error while updating');
+            
         });
     };
     // ## Add a worklog to a project ##
@@ -909,6 +1029,12 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         };
 
         this.request(options, function(error, response, body) {
+ 
+            if (error) {
+                callback(error, null);
+                return;
+            }
+ 
             if (response.statusCode === 201) {
                 callback(null, "Success");
                 return;
@@ -921,7 +1047,9 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
                 callback("Insufficient Permissions");
                 return;
             }
+            
             callback(response.statusCode + ': Error while updating');
+            
         });
     };
     // ## List all Issue Types ##
@@ -953,11 +1081,19 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         };
 
         this.request(options, function(error, response, body) {
+
+            if (error) {
+                callback(error, null);
+                return;
+            }
+            
             if (response.statusCode === 200) {
                 callback(null, body);
                 return;
             }
-            callback(response.statusCode + ': Error while retreiving issue types');
+            
+            callback(response.statusCode + ': Error while retrieving issue types');
+            
         });
     };
 


### PR DESCRIPTION
If an error is returned by a http request, there is no response object which will lead to a crash with an error like "could not get statusCode of undefined".
To prevent this crash, we need an error handler.

An error on a request can occur when per example the jira server is not available. (e.g. no Internet Connection)

Can somebody please update the docs. I don't know how to do that.
