### PR TITLE
addComment API functionality

### DIFF
--- a/lib/jira.js
+++ b/lib/jira.js
@@ -1019,6 +1019,46 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             
         });
     };
+    // ## Add a comment to an issue ##
+    // ### Takes ###
+    // *  issueId: Issue to add a comment to
+    // *  comment: string containing comment
+    // *  callback: for when it's done
+    //
+    // ### Returns ###
+    // *  error string
+    // *  success string
+    //
+    // [Jira Doc](https://docs.atlassian.com/jira/REST/latest/#id108798)
+    this.addComment = function(issueId, comment, callback){
+        var options = {
+            rejectUnauthorized: this.strictSSL,
+            uri: this.makeUri('/issue/' + issueId + '/comment'),
+            body: {
+              "body": comment
+            },
+            method: 'POST',
+            followAllRedirects: true,
+            json: true
+        };
+
+        this.request(options, function(error, response, body) {
+            if (error) {
+                callback(error, null);
+                return;
+            };
+
+            if (response.statusCode === 201) {
+                callback(null, "Success");
+                return;
+            };
+
+            if (response.statusCode === 400) {
+                callback("Invalid Fields: " + JSON.stringify(body));
+                return;
+            };
+        });
+    };
     // ## Add a worklog to a project ##
     // ### Takes ###
     // *  issueId: Issue to add a worklog to

--- a/spec/jira.spec.coffee
+++ b/spec/jira.spec.coffee
@@ -424,6 +424,28 @@ describe "Node Jira Tests", ->
         @jira.request.mostRecentCall.args[1] null, statusCode:200, "body"
         expect(@cb).toHaveBeenCalledWith null, "body"
 
+    it "Adds a comment to an issue", ->
+        options =
+            rejectUnauthorized: true
+            uri: makeUrl "issue/1/comment"
+            body: {
+                'body': 'aComment'
+            }
+            method: 'POST'
+            followAllRedirects: true
+            json: true
+
+        @jira.addComment 1, 'aComment', @cb
+        expect(@jira.request).toHaveBeenCalledWith options, jasmine.any(Function)
+
+        @jira.request.mostRecentCall.args[1] null, statusCode:400,
+            '{"body:"none"}'
+        expect(@cb).toHaveBeenCalledWith 'Invalid Fields: "{\\"body:\\"none\\"}"'
+
+        # Successful Request
+        @jira.request.mostRecentCall.args[1] null, statusCode:201
+        expect(@cb).toHaveBeenCalledWith null, "Success"
+
     it "Adds a worklog to a project", ->
         options =
             rejectUnauthorized: true


### PR DESCRIPTION
Hi there,

I have added the functionality to use the addComment API functionality that I've been using for a project of mine.

I have added the code for the jira.spec.coffee but I cannot figure out how to run the tests but manual testing indicates that it is working fine (yeah I know, "works on my machine" code)

More than happy to accept criticism and points on how/where to run the tests. Still a little new to NodeJS as well.

Thanks,

Steve
