### PR TITLE
Added a check for when the body variable is undefined.

### DIFF
--- a/lib/jira.js
+++ b/lib/jira.js
@@ -184,6 +184,10 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
                 return;
             }
 
+            if (body === undefined) {
+                callback('Response body was undefined.');
+            }
+
             callback(null, JSON.parse(body));
 
         });


### PR DESCRIPTION
This is triggered when many requests are submitted in quick succession and the Jira server doesn't return a valid response.  The request should be retried if this error is thrown.
