### PR TITLE
Support for webhooks and getting current user info

### DIFF
--- a/lib/jira.js
+++ b/lib/jira.js
@@ -1646,7 +1646,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
                 return;
             }
 
-            callback(response.statusCode + ': Error while deleting webhook');
+            callback(response.statusCode + ': Error while getting current user');
 
         });
     };


### PR DESCRIPTION
I added the following methods for dealing with webhooks:
- `registerWebhook()`
- `listWebhooks()`
- `getWebhook()`
- `deleteWebhook()`

Not related to webhooks, but this method returns information on the currently authenticated user:
- `getCurrentUser()`

To get the above working, I had to extend `makeUri()` to take `altApiVersion` as an argument so that you can use an `altBase` that has a different version.
