### PR TITLE
listTransitions response fix; addComment error handling

### DIFF
--- a/lib/jira.js
+++ b/lib/jira.js
@@ -1301,6 +1301,8 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
                 callback("Invalid Fields: " + JSON.stringify(body));
                 return;
             };
+            
+            callback(response.statusCode + ': Error while updating');
         });
     };
     // ## Add a worklog to a project ##


### PR DESCRIPTION
Hope this helps!

listTransitions -- was returning undefined to me (using 2.0.alpha1), but when I removed the parameter I got the correct result.

addComment -- had no error handling if the statusCode wasn't a 201 or 400.
