### PR TITLE
Add support for corporate http(s) proxies, via request `proxy` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ JiraApi options:
 *  `Jira API Version<string>`: Known to work with `2` and `2.0.alpha1`
 *  `verbose<bool>`: Log some info to the console, usually for debugging
 *  `strictSSL<bool>`: Set to false if you have self-signed certs or something non-trustworthy
+*  `proxy<string>`: Set to a string like `http://company.com:port/` (same syntax as [request](https://npmjs.org/package/request)).
 
 ## Implemented APIs ##
 

--- a/lib/jira.js
+++ b/lib/jira.js
@@ -125,13 +125,14 @@ var url = require('url'),
     logger = console;
 
 
-var JiraApi = exports.JiraApi = function(protocol, host, port, username, password, apiVersion, verbose, strictSSL) {
+var JiraApi = exports.JiraApi = function(protocol, host, port, username, password, apiVersion, verbose, strictSSL, proxy) {
     this.protocol = protocol;
     this.host = host;
     this.port = port;
     this.username = username;
     this.password = password;
     this.apiVersion = apiVersion;
+    this.proxy = proxy;
     // Default strictSSL to true (previous behavior) but now allow it to be
     // modified
     if (strictSSL == null) {
@@ -181,7 +182,8 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         var options = {
             rejectUnauthorized: this.strictSSL,
             uri: this.makeUri('/issue/' + issueNumber),
-            method: 'GET'
+            method: 'GET',
+            proxy: this.proxy
         };
 
         this.request(options, function(error, response, body) {
@@ -226,7 +228,8 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         var options = {
             rejectUnauthorized: this.strictSSL,
             uri: this.makeUri('/version/' + version + '/unresolvedIssueCount'),
-            method: 'GET'
+            method: 'GET',
+            proxy: this.proxy
         };
 
         this.request(options, function(error, response, body) {
@@ -269,7 +272,8 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         var options = {
             rejectUnauthorized: this.strictSSL,
             uri: this.makeUri('/project/' + project),
-            method: 'GET'
+            method: 'GET',
+            proxy: this.proxy
         };
 
         this.request(options, function(error, response, body) {
@@ -317,7 +321,8 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
           rejectUnauthorized: this.strictSSL,
           uri: this.makeUri('/rapidviews/list', 'rest/greenhopper/'),
           method: 'GET',
-          json: true
+          json: true,
+          proxy: this.proxy
         };
 
         this.request(options, function(error, response) {
@@ -372,7 +377,8 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
           rejectUnauthorized: this.strictSSL,
           uri: this.makeUri('/sprints/' + rapidViewId, 'rest/greenhopper/'),
           method: 'GET',
-          json:true
+          json:true,
+          proxy: this.proxy
         };
 
         this.request(options, function(error, response) {
@@ -425,7 +431,8 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         rejectUnauthorized: this.strictSSL,
         uri: this.makeUri('/rapid/charts/sprintreport?rapidViewId=' + rapidViewId + '&sprintId=' + sprintId, 'rest/greenhopper/'),
         method: 'GET',
-        json: true
+        json: true,
+        proxy: this.proxy
       };
 
       this.request(options, function(error, response) {
@@ -485,7 +492,8 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
           json:true,
           body: {
             issueKeys: [issueId]
-          }
+          },
+          proxy: this.proxy
         };
 
         logger.log(options.uri);
@@ -548,7 +556,8 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             method: 'POST',
             followAllRedirects: true,
             json: true,
-            body: link
+            body: link,
+            proxy: this.proxy
         };
 
         this.request(options, function(error, response) {
@@ -589,7 +598,8 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         var options = {
             rejectUnauthorized: this.strictSSL,
             uri: this.makeUri('/project/' + project + '/versions'),
-            method: 'GET'
+            method: 'GET',
+            proxy: this.proxy
         };
 
         this.request(options, function(error, response, body) {
@@ -646,7 +656,8 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             method: 'POST',
             followAllRedirects: true,
             json: true,
-            body: version
+            body: version,
+            proxy: this.proxy
         };
         this.request(options, function(error, response, body) {
 
@@ -714,7 +725,8 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
                 startAt: optional.startAt || 0,
                 maxResults: optional.maxResults || 50,
                 fields: optional.fields || ["summary", "status", "assignee", "description"]
-            }
+            },
+            proxy: this.proxy
         };
 
         this.request(options, function(error, response, body) {
@@ -772,7 +784,8 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
                 '&includeInactive=' + includeInactive),
             method: 'GET',
             json: true,
-            followAllRedirects: true
+            followAllRedirects: true,
+            proxy: this.proxy
         };
 
         this.request(options, function(error, response, body) {
@@ -836,7 +849,8 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             method: 'POST',
             followAllRedirects: true,
             json: true,
-            body: issue
+            body: issue,
+            proxy: this.proxy
         };
 
         this.request(options, function(error, response, body) {
@@ -877,7 +891,8 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             uri: this.makeUri('/issue/' + issueNum),
             method: 'DELETE',
             followAllRedirects: true,
-            json: true
+            json: true,
+            proxy: this.proxy
         };
 
         this.request(options, function(error, response) {
@@ -915,7 +930,8 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             body: issueUpdate,
             method: 'PUT',
             followAllRedirects: true,
-            json: true
+            json: true,
+            proxy: this.proxy
         };
 
         this.request(options, function(error, response) {
@@ -974,7 +990,8 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             rejectUnauthorized: this.strictSSL,
             uri: this.makeUri('/project/' + project + '/components'),
             method: 'GET',
-            json: true
+            json: true,
+            proxy: this.proxy
         };
 
         this.request(options, function(error, response, body) {
@@ -1027,7 +1044,8 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             rejectUnauthorized: this.strictSSL,
             uri: this.makeUri('/field'),
             method: 'GET',
-            json: true
+            json: true,
+            proxy: this.proxy
         };
 
         this.request(options, function(error, response, body) {
@@ -1075,7 +1093,8 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             rejectUnauthorized: this.strictSSL,
             uri: this.makeUri('/priority'),
             method: 'GET',
-            json: true
+            json: true,
+            proxy: this.proxy
         };
 
         this.request(options, function(error, response, body) {
@@ -1152,7 +1171,8 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             rejectUnauthorized: this.strictSSL,
             uri: this.makeUri('/issue/' + issueId + '/transitions?expand=transitions.fields'),
             method: 'GET',
-            json: true
+            json: true,
+            proxy: this.proxy
         };
 
         this.request(options, function(error, response, body) {
@@ -1194,7 +1214,8 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             body: issueTransition,
             method: 'POST',
             followAllRedirects: true,
-            json: true
+            json: true,
+            proxy: this.proxy
         };
 
         this.request(options, function(error, response) {
@@ -1242,7 +1263,8 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             rejectUnauthorized: this.strictSSL,
             uri: this.makeUri('/project'),
             method: 'GET',
-            json: true
+            json: true,
+            proxy: this.proxy
         };
 
         this.request(options, function(error, response, body) {
@@ -1285,7 +1307,8 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             },
             method: 'POST',
             followAllRedirects: true,
-            json: true
+            json: true,
+            proxy: this.proxy
         };
 
         this.request(options, function(error, response, body) {
@@ -1350,7 +1373,8 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             body: worklog,
             method: 'POST',
             followAllRedirects: true,
-            json: true
+            json: true,
+            proxy: this.proxy
         };
 
         this.request(options, function(error, response, body) {
@@ -1403,7 +1427,8 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             rejectUnauthorized: this.strictSSL,
             uri: this.makeUri('/issuetype'),
             method: 'GET',
-            json: true
+            json: true,
+            proxy: this.proxy
         };
 
         this.request(options, function(error, response, body) {


### PR DESCRIPTION
This is something that is (was) missing from `node-jira` when trying to use `*.atlassian.net` from behind a corporate proxy.
