### PR TITLE
replaces /sprints route with /sprintquery according to https://jira.atla...

### DIFF
--- a/lib/jira.js
+++ b/lib/jira.js
@@ -370,7 +370,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
 
         var options = {
           rejectUnauthorized: this.strictSSL,
-          uri: this.makeUri('/sprints/' + rapidViewId, 'rest/greenhopper/'),
+          uri: this.makeUri('/sprintquery/' + rapidViewId, 'rest/greenhopper/'),
           method: 'GET',
           json:true
         };

--- a/spec/jira.spec.coffee
+++ b/spec/jira.spec.coffee
@@ -130,7 +130,7 @@ describe "Node Jira Tests", ->
     it "Gets the last sprint for a Rapid View", ->
         options =
             rejectUnauthorized: true
-            uri: makeUrl("sprints/1", true)
+            uri: makeUrl("sprintquery/1", true)
             method: 'GET'
             json: true
 


### PR DESCRIPTION
the route /sprints has changed to /sprintquery
see https://jira.atlassian.com/browse/GHS-9321
