### PR TITLE
Adding the body to the error requests

### DIFF
--- a/lib/jira.js
+++ b/lib/jira.js
@@ -214,22 +214,22 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         this.doRequest(options, function(error, response, body) {
 
             if (error) {
-                callback(error, null);
+                callback(error, body);
                 return;
             }
 
             if (response.statusCode === 404) {
-                callback('Invalid issue number.');
+                callback('Invalid issue number.', body);
                 return;
             }
 
             if (response.statusCode !== 200) {
-                callback(response.statusCode + ': Unable to connect to JIRA during findIssueStatus.');
+                callback(response.statusCode + ': Unable to connect to JIRA during findIssueStatus.', body);
                 return;
             }
 
             if (body === undefined) {
-                callback('Response body was undefined.');
+                callback('Response body was undefined.', body);
             }
 
             callback(null, JSON.parse(body));
@@ -259,17 +259,17 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         this.doRequest(options, function(error, response, body) {
 
             if (error) {
-                callback(error, null);
+                callback(error, body);
                 return;
             }
 
             if (response.statusCode === 404) {
-                callback('Invalid version.');
+                callback('Invalid version.', body);
                 return;
             }
 
             if (response.statusCode !== 200) {
-                callback(response.statusCode + ': Unable to connect to JIRA during findIssueStatus.');
+                callback(response.statusCode + ': Unable to connect to JIRA during findIssueStatus.', body);
                 return;
             }
 
@@ -302,17 +302,17 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         this.doRequest(options, function(error, response, body) {
 
             if (error) {
-                callback(error, null);
+                callback(error, body);
                 return;
             }
 
             if (response.statusCode === 404) {
-                callback('Invalid project.');
+                callback('Invalid project.', body);
                 return;
             }
 
             if (response.statusCode !== 200) {
-                callback(response.statusCode + ': Unable to connect to JIRA during getProject.');
+                callback(response.statusCode + ': Unable to connect to JIRA during getProject.', body);
                 return;
             }
 
@@ -347,20 +347,20 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
           json: true
         };
 
-        this.doRequest(options, function(error, response) {
+        this.doRequest(options, function(error, response, body) {
 
           if (error) {
-              callback(error, null);
+              callback(error, body);
               return;
           }
 
           if (response.statusCode === 404) {
-            callback('Invalid URL');
+            callback('Invalid URL', body);
             return;
           }
 
           if (response.statusCode !== 200) {
-            callback(response.statusCode + ': Unable to connect to JIRA during rapidView search.');
+            callback(response.statusCode + ': Unable to connect to JIRA during rapidView search.', body);
             return;
           }
 
@@ -402,20 +402,20 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
           json:true
         };
 
-        this.doRequest(options, function(error, response) {
+        this.doRequest(options, function(error, response, body) {
 
           if (error) {
-              callback(error, null);
+              callback(error, body);
               return;
           }
 
           if (response.statusCode === 404) {
-            callback('Invalid URL');
+            callback('Invalid URL', body);
             return;
           }
 
           if (response.statusCode !== 200) {
-            callback(response.statusCode + ': Unable to connect to JIRA during sprints search.');
+            callback(response.statusCode + ': Unable to connect to JIRA during sprints search.', body);
             return;
           }
 
@@ -455,28 +455,24 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         json: true
       };
 
-      this.doRequest(options, function(error, response) {
+      this.doRequest(options, function(error, response, body) {
 
         if (error) {
-            callback(error, null);
+            callback(error, body);
             return;
         }
 
         if( response.statusCode === 404 ) {
-          callback('Invalid URL');
+          callback('Invalid URL', body);
           return;
         }
 
         if( response.statusCode !== 200 ) {
-          callback(response.statusCode + ': Unable to connect to JIRA during sprints search');
+          callback(response.statusCode + ': Unable to connect to JIRA during sprints search', null);
           return;
         }
 
-        if(response.body !== null) {
-          callback(null, response.body);
-        } else {
-          callback('No body');
-        }
+        callback((body === null ? 'No body' : null), body);
 
       });
 
@@ -517,20 +513,20 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
 
         logger.log(options.uri);
 
-        this.doRequest(options, function(error, response) {
+        this.doRequest(options, function(error, response, body) {
 
           if (error) {
-              callback(error, null);
+              callback(error, body);
               return;
           }
 
           if (response.statusCode === 404) {
-            callback('Invalid URL');
+            callback('Invalid URL', body);
             return;
           }
 
           if (response.statusCode !== 204) {
-            callback(response.statusCode + ': Unable to connect to JIRA to add to sprint.');
+            callback(response.statusCode + ': Unable to connect to JIRA to add to sprint.', body);
             return;
           }
 
@@ -578,24 +574,24 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             body: link
         };
 
-        this.doRequest(options, function(error, response) {
+        this.doRequest(options, function(error, response, body) {
 
             if (error) {
-                callback(error, null);
+                callback(error, body);
                 return;
             }
 
             if (response.statusCode === 404) {
-                callback('Invalid project.');
+                callback('Invalid project.', body);
                 return;
             }
 
             if (response.statusCode !== 200) {
-                callback(response.statusCode + ': Unable to connect to JIRA during issueLink.');
+                callback(response.statusCode + ': Unable to connect to JIRA during issueLink.', body);
                 return;
             }
 
-            callback(null);
+            callback(null, body);
 
         });
     };
@@ -622,17 +618,17 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         this.doRequest(options, function(error, response, body) {
 
             if (error) {
-                callback(error, null);
+                callback(error, body);
                 return;
             }
 
             if (response.statusCode === 404) {
-                callback('Invalid project.');
+                callback('Invalid project.', body);
                 return;
             }
 
             if (response.statusCode !== 200) {
-                callback(response.statusCode + ': Unable to connect to JIRA during getVersions.');
+                callback(response.statusCode + ': Unable to connect to JIRA during getVersions.', body);
                 return;
             }
 
@@ -678,22 +674,22 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         this.doRequest(options, function(error, response, body) {
 
             if (error) {
-                callback(error, null);
+                callback(error, body);
                 return;
             }
 
             if (response.statusCode === 404) {
-                callback('Version does not exist or the currently authenticated user does not have permission to view it');
+                callback('Version does not exist or the currently authenticated user does not have permission to view it', body);
                 return;
             }
 
             if (response.statusCode === 403) {
-                callback('The currently authenticated user does not have permission to edit the version');
+                callback('The currently authenticated user does not have permission to edit the version', body);
                 return;
             }
 
             if (response.statusCode !== 201) {
-                callback(response.statusCode + ': Unable to connect to JIRA during createVersion.');
+                callback(response.statusCode + ': Unable to connect to JIRA during createVersion.', body);
                 return;
             }
 
@@ -739,22 +735,22 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         this.doRequest(options, function(error, response, body) {
 
             if (error) {
-                callback(error, null);
+                callback(error, body);
                 return;
             }
 
             if (response.statusCode === 404) {
-                callback('Version does not exist or the currently authenticated user does not have permission to view it');
+                callback('Version does not exist or the currently authenticated user does not have permission to view it', body);
                 return;
             }
 
             if (response.statusCode === 403) {
-                callback('The currently authenticated user does not have permission to edit the version');
+                callback('The currently authenticated user does not have permission to edit the version', body);
                 return;
             }
 
             if (response.statusCode !== 200) {
-                callback(response.statusCode + ': Unable to connect to JIRA during updateVersion.');
+                callback(response.statusCode + ': Unable to connect to JIRA during updateVersion.', body);
                 return;
             }
 
@@ -808,17 +804,17 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         this.doRequest(options, function(error, response, body) {
 
             if (error) {
-                callback(error, null);
+                callback(error, body);
                 return;
             }
 
             if (response.statusCode === 400) {
-                callback('Problem with the JQL query');
+                callback('Problem with the JQL query', body);
                 return;
             }
 
             if (response.statusCode !== 200) {
-                callback(response.statusCode + ': Unable to connect to JIRA during search.');
+                callback(response.statusCode + ': Unable to connect to JIRA during search.', body);
                 return;
             }
 
@@ -866,17 +862,17 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         this.doRequest(options, function(error, response, body) {
 
             if (error) {
-                callback(error, null);
+                callback(error, body);
                 return;
             }
 
             if (response.statusCode === 400) {
-                callback('Unable to search');
+                callback('Unable to search', body);
                 return;
             }
 
             if (response.statusCode !== 200) {
-                callback(response.statusCode + ': Unable to connect to JIRA during search.');
+                callback(response.statusCode + ': Unable to connect to JIRA during search.', body);
                 return;
             }
 
@@ -930,17 +926,17 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         this.doRequest(options, function(error, response, body) {
 
             if (error) {
-                callback(error, null);
+                callback(error, body);
                 return;
             }
 
             if (response.statusCode === 400) {
-                callback(body);
+                callback(body, null);
                 return;
             }
 
             if ((response.statusCode !== 200) && (response.statusCode !== 201)) {
-                callback(response.statusCode + ': Unable to connect to JIRA during search.');
+                callback(response.statusCode + ': Unable to connect to JIRA during search.', body);
                 return;
             }
 
@@ -968,10 +964,10 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             json: true
         };
 
-        this.doRequest(options, function(error, response) {
+        this.doRequest(options, function(error, response, body) {
 
             if (error) {
-                callback(error, null);
+                callback(error, body);
                 return;
             }
 
@@ -980,7 +976,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
                 return;
             }
 
-            callback(response.statusCode + ': Error while deleting');
+            callback(response.statusCode + ': Error while deleting', body);
 
         });
     };
@@ -1006,10 +1002,10 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             json: true
         };
 
-        this.doRequest(options, function(error, response) {
+        this.doRequest(options, function(error, response, body) {
 
             if (error) {
-                callback(error, null);
+                callback(error, body);
                 return;
             }
 
@@ -1018,7 +1014,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
                 return;
             }
 
-            callback(response.statusCode + ': Error while updating');
+            callback(response.statusCode + ': Error while updating', body);
 
         });
     };
@@ -1068,7 +1064,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         this.doRequest(options, function(error, response, body) {
 
             if (error) {
-                callback(error, null);
+                callback(error, body);
                 return;
             }
 
@@ -1077,11 +1073,11 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
                 return;
             }
             if (response.statusCode === 404) {
-                callback("Project not found");
+                callback("Project not found", body);
                 return;
             }
 
-            callback(response.statusCode + ': Error while updating');
+            callback(response.statusCode + ': Error while updating', body);
 
         });
     };
@@ -1121,7 +1117,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         this.doRequest(options, function(error, response, body) {
 
             if (error) {
-                callback(error, null);
+                callback(error, body);
                 return;
             }
 
@@ -1130,11 +1126,11 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
                 return;
             }
             if (response.statusCode === 404) {
-                callback("Not found");
+                callback("Not found", body);
                 return;
             }
 
-            callback(response.statusCode + ': Error while updating');
+            callback(response.statusCode + ': Error while updating', body);
 
         });
     };
@@ -1169,7 +1165,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         this.doRequest(options, function(error, response, body) {
 
             if (error) {
-                callback(error, null);
+                callback(error, body);
                 return;
             }
 
@@ -1178,11 +1174,11 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
                 return;
             }
             if (response.statusCode === 404) {
-                callback("Not found");
+                callback("Not found", body);
                 return;
             }
 
-            callback(response.statusCode + ': Error while updating');
+            callback(response.statusCode + ': Error while updating', body);
 
         });
     };
@@ -1246,7 +1242,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         this.doRequest(options, function(error, response, body) {
 
             if (error) {
-                callback(error, null);
+                callback(error, body);
                 return;
             }
 
@@ -1255,11 +1251,11 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
                 return;
             }
             if (response.statusCode === 404) {
-                callback("Issue not found");
+                callback("Issue not found", body);
                 return;
             }
 
-            callback(response.statusCode + ': Error while updating');
+            callback(response.statusCode + ': Error while updating', body);
 
         });
     };
@@ -1285,10 +1281,10 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             json: true
         };
 
-        this.doRequest(options, function(error, response) {
+        this.doRequest(options, function(error, response, body) {
 
             if (error) {
-                callback(error, null);
+                callback(error, body);
                 return;
             }
 
@@ -1297,7 +1293,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
                 return;
             }
 
-            callback(response.statusCode + ': Error while updating');
+            callback(response.statusCode + ': Error while updating', body);
 
         });
     };
@@ -1336,7 +1332,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         this.doRequest(options, function(error, response, body) {
 
             if (error) {
-                callback(error, null);
+                callback(error, body);
                 return;
             }
 
@@ -1345,11 +1341,11 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
                 return;
             }
             if (response.statusCode === 500) {
-                callback(response.statusCode + ': Error while retrieving list.');
+                callback(response.statusCode + ': Error while retrieving list.', body);
                 return;
             }
 
-            callback(response.statusCode + ': Error while updating');
+            callback(response.statusCode + ': Error while updating', body);
 
         });
     };
@@ -1378,7 +1374,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
 
         this.doRequest(options, function(error, response, body) {
             if (error) {
-                callback(error, null);
+                callback(error, body);
                 return;
             }
 
@@ -1388,7 +1384,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             }
 
             if (response.statusCode === 400) {
-                callback("Invalid Fields: " + JSON.stringify(body));
+                callback("Invalid Fields: " + JSON.stringify(body), body);
                 return;
             }
         });
@@ -1448,7 +1444,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         this.doRequest(options, function(error, response, body) {
 
             if (error) {
-                callback(error, null);
+                callback(error, body);
                 return;
             }
 
@@ -1461,11 +1457,11 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
                 return;
             }
             if (response.statusCode === 403) {
-                callback("Insufficient Permissions");
+                callback("Insufficient Permissions", body);
                 return;
             }
 
-            callback(response.statusCode + ': Error while updating');
+            callback(response.statusCode + ': Error while updating', body);
 
         });
     };
@@ -1501,7 +1497,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         this.doRequest(options, function(error, response, body) {
 
             if (error) {
-                callback(error, null);
+                callback(error, body);
                 return;
             }
 
@@ -1510,7 +1506,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
                 return;
             }
 
-            callback(response.statusCode + ': Error while retrieving issue types');
+            callback(response.statusCode + ': Error while retrieving issue types', body);
 
         });
     };
@@ -1553,7 +1549,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         this.request(options, function(error, response, body) {
 
             if (error) {
-                callback(error, null);
+                callback(error, body);
                 return;
             }
 
@@ -1562,7 +1558,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
                 return;
             }
 
-            callback(response.statusCode + ': Error while registering new webhook');
+            callback(response.statusCode + ': Error while registering new webhook', body);
 
         });
     };
@@ -1603,7 +1599,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         this.request(options, function(error, response, body) {
 
             if (error) {
-                callback(error, null);
+                callback(error, body);
                 return;
             }
 
@@ -1612,7 +1608,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
                 return;
             }
 
-            callback(response.statusCode + ': Error while listing webhooks');
+            callback(response.statusCode + ': Error while listing webhooks', body);
 
         });
     };
@@ -1639,7 +1635,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         this.request(options, function(error, response, body) {
 
             if (error) {
-                callback(error, null);
+                callback(error, body);
                 return;
             }
 
@@ -1648,7 +1644,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
                 return;
             }
 
-            callback(response.statusCode + ': Error while getting webhook');
+            callback(response.statusCode + ': Error while getting webhook', body);
 
         });
     };
@@ -1675,7 +1671,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         this.request(options, function(error, response, body) {
 
             if (error) {
-                callback(error, null);
+                callback(error, body);
                 return;
             }
 
@@ -1684,7 +1680,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
                 return;
             }
 
-            callback(response.statusCode + ': Error while deleting webhook');
+            callback(response.statusCode + ': Error while deleting webhook', body);
 
         });
     };
@@ -1726,7 +1722,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         this.request(options, function(error, response, body) {
 
             if (error) {
-                callback(error, null);
+                callback(error, body);
                 return;
             }
 
@@ -1735,7 +1731,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
                 return;
             }
 
-            callback(response.statusCode + ': Error while getting current user');
+            callback(response.statusCode + ': Error while getting current user', body);
 
         });
     };
@@ -1814,9 +1810,9 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
 			json: true
 		};
 
-		this.doRequest(options, function(error, response) {
+		this.doRequest(options, function(error, response, body) {
 			if (error) {
-				callback(error, null);
+				callback(error, body);
 
 				return;
 			}
@@ -1827,7 +1823,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
 				return;
 			}
 
-			callback(response.statusCode + ': Error while retrieving backlog');
+			callback(response.statusCode + ': Error while retrieving backlog', body);
 		});
 	};
 

--- a/spec/jira.spec.coffee
+++ b/spec/jira.spec.coffee
@@ -76,12 +76,12 @@ describe "Node Jira Tests", ->
 
         # Invalid issue number (different than unable to find??)
         @jira.request.mostRecentCall.args[1] null, statusCode:404, null
-        expect(@cb).toHaveBeenCalledWith 'Invalid issue number.'
+        expect(@cb).toHaveBeenCalledWith 'Invalid issue number.', null
 
         # Unable to find issue
         @jira.request.mostRecentCall.args[1] null, statusCode:401, null
         expect(@cb).toHaveBeenCalledWith(
-            '401: Unable to connect to JIRA during findIssueStatus.')
+            '401: Unable to connect to JIRA during findIssueStatus.', null)
 
         # Successful Request
         @jira.request.mostRecentCall.args[1] null,
@@ -103,12 +103,12 @@ describe "Node Jira Tests", ->
 
         # Invalid Version
         @jira.request.mostRecentCall.args[1] null, statusCode:404, null
-        expect(@cb).toHaveBeenCalledWith 'Invalid version.'
+        expect(@cb).toHaveBeenCalledWith 'Invalid version.', null
 
         # Unable to connect
         @jira.request.mostRecentCall.args[1] null, statusCode:401, null
         expect(@cb).toHaveBeenCalledWith(
-            '401: Unable to connect to JIRA during findIssueStatus.')
+            '401: Unable to connect to JIRA during findIssueStatus.', null)
         
         # Successful Request
         @jira.request.mostRecentCall.args[1] null,
@@ -130,7 +130,7 @@ describe "Node Jira Tests", ->
 
         # Invalid Version
         @jira.request.mostRecentCall.args[1] null, statusCode:404, null
-        expect(@cb).toHaveBeenCalledWith 'Invalid project.'
+        expect(@cb).toHaveBeenCalledWith 'Invalid project.', null
 
         # Successful Request
         @jira.request.mostRecentCall.args[1] null,
@@ -153,11 +153,11 @@ describe "Node Jira Tests", ->
 
         # Invalid URL 
         @jira.request.mostRecentCall.args[1] null, statusCode:404, null
-        expect(@cb).toHaveBeenCalledWith 'Invalid URL'
+        expect(@cb).toHaveBeenCalledWith 'Invalid URL', null
 
         @jira.request.mostRecentCall.args[1] null, statusCode:401, null
         expect(@cb).toHaveBeenCalledWith(
-            '401: Unable to connect to JIRA during rapidView search.')
+            '401: Unable to connect to JIRA during rapidView search.', null)
 
         # Successful Request
         @jira.request.mostRecentCall.args[1] null,
@@ -182,11 +182,11 @@ describe "Node Jira Tests", ->
 
         # Invalid URL 
         @jira.request.mostRecentCall.args[1] null, statusCode:404, null
-        expect(@cb).toHaveBeenCalledWith 'Invalid URL'
+        expect(@cb).toHaveBeenCalledWith 'Invalid URL', null
 
         @jira.request.mostRecentCall.args[1] null, statusCode:401, null
         expect(@cb).toHaveBeenCalledWith(
-            '401: Unable to connect to JIRA during sprints search.')
+            '401: Unable to connect to JIRA during sprints search.', null)
 
         # Successful Request
         @jira.request.mostRecentCall.args[1] null,
@@ -214,11 +214,11 @@ describe "Node Jira Tests", ->
 
         # Invalid URL 
         @jira.request.mostRecentCall.args[1] null, statusCode:404, null
-        expect(@cb).toHaveBeenCalledWith 'Invalid URL'
+        expect(@cb).toHaveBeenCalledWith 'Invalid URL', null
 
         @jira.request.mostRecentCall.args[1] null, statusCode:401, null
         expect(@cb).toHaveBeenCalledWith(
-            '401: Unable to connect to JIRA to add to sprint.')
+            '401: Unable to connect to JIRA to add to sprint.', null)
 
     it "Creates a Link Between two Issues", ->
         options =
@@ -237,15 +237,15 @@ describe "Node Jira Tests", ->
 
         # Invalid Project
         @jira.request.mostRecentCall.args[1] null, statusCode:404, null
-        expect(@cb).toHaveBeenCalledWith 'Invalid project.'
+        expect(@cb).toHaveBeenCalledWith 'Invalid project.', null
 
         @jira.request.mostRecentCall.args[1] null, statusCode:401, null
         expect(@cb).toHaveBeenCalledWith(
-            '401: Unable to connect to JIRA during issueLink.')
+            '401: Unable to connect to JIRA during issueLink.', null)
 
         # Successful Request
         @jira.request.mostRecentCall.args[1] null, statusCode:200
-        expect(@cb).toHaveBeenCalledWith null
+        expect(@cb).toHaveBeenCalledWith null, undefined
 
     it "Gets versions for a project", ->
         options =
@@ -261,11 +261,11 @@ describe "Node Jira Tests", ->
 
         # Invalid Project
         @jira.request.mostRecentCall.args[1] null, statusCode:404, null
-        expect(@cb).toHaveBeenCalledWith 'Invalid project.'
+        expect(@cb).toHaveBeenCalledWith 'Invalid project.', null
 
         @jira.request.mostRecentCall.args[1] null, statusCode:401, null
         expect(@cb).toHaveBeenCalledWith(
-            '401: Unable to connect to JIRA during getVersions.')
+            '401: Unable to connect to JIRA during getVersions.', null)
 
         # Successful Request
         @jira.request.mostRecentCall.args[1] null,
@@ -290,16 +290,16 @@ describe "Node Jira Tests", ->
         # Invalid Project
         @jira.request.mostRecentCall.args[1] null, statusCode:404, null
         expect(@cb).toHaveBeenCalledWith 'Version does not exist or the
- currently authenticated user does not have permission to view it'
+ currently authenticated user does not have permission to view it', null
 
         @jira.request.mostRecentCall.args[1] null, statusCode:403, null
         expect(@cb).toHaveBeenCalledWith(
             'The currently authenticated user does not have
- permission to edit the version')
+ permission to edit the version', null)
 
         @jira.request.mostRecentCall.args[1] null, statusCode:401, null
         expect(@cb).toHaveBeenCalledWith(
-            '401: Unable to connect to JIRA during createVersion.')
+            '401: Unable to connect to JIRA during createVersion.', null)
 
         # Successful Request
         @jira.request.mostRecentCall.args[1] null,
@@ -328,11 +328,11 @@ describe "Node Jira Tests", ->
 
         # Invalid Project
         @jira.request.mostRecentCall.args[1] null, statusCode:400, null
-        expect(@cb).toHaveBeenCalledWith 'Problem with the JQL query'
+        expect(@cb).toHaveBeenCalledWith 'Problem with the JQL query', null
 
         @jira.request.mostRecentCall.args[1] null, statusCode:401, null
         expect(@cb).toHaveBeenCalledWith(
-            '401: Unable to connect to JIRA during search.')
+            '401: Unable to connect to JIRA during search.', null)
 
         # Successful Request
         @jira.request.mostRecentCall.args[1] null,
@@ -382,7 +382,7 @@ describe "Node Jira Tests", ->
         expect(@jira.request).toHaveBeenCalledWith options, jasmine.any(Function)
 
         @jira.request.mostRecentCall.args[1] null, statusCode:404, null
-        expect(@cb).toHaveBeenCalledWith 'Invalid URL'
+        expect(@cb).toHaveBeenCalledWith 'Invalid URL', null
 
      it "Gets ALL a specified User's Issues", ->
         spyOn @jira, 'searchJira'
@@ -407,7 +407,7 @@ describe "Node Jira Tests", ->
         expect(@jira.request).toHaveBeenCalledWith options, jasmine.any(Function)
 
         @jira.request.mostRecentCall.args[1] null, statusCode:401, null
-        expect(@cb).toHaveBeenCalledWith '401: Error while deleting'
+        expect(@cb).toHaveBeenCalledWith '401: Error while deleting', null
 
         # Successful Request
         @jira.request.mostRecentCall.args[1] null, statusCode:204
@@ -429,7 +429,7 @@ describe "Node Jira Tests", ->
         expect(@jira.request).toHaveBeenCalledWith options, jasmine.any(Function)
 
         @jira.request.mostRecentCall.args[1] null, statusCode:401
-        expect(@cb).toHaveBeenCalledWith '401: Error while updating'
+        expect(@cb).toHaveBeenCalledWith '401: Error while updating', undefined
 
         # Successful Request
         @jira.request.mostRecentCall.args[1] null, statusCode:200
@@ -449,10 +449,10 @@ describe "Node Jira Tests", ->
         expect(@jira.request).toHaveBeenCalledWith options, jasmine.any(Function)
 
         @jira.request.mostRecentCall.args[1] null, statusCode:404, null
-        expect(@cb).toHaveBeenCalledWith 'Issue not found'
+        expect(@cb).toHaveBeenCalledWith 'Issue not found', null
 
         @jira.request.mostRecentCall.args[1] null, statusCode:401
-        expect(@cb).toHaveBeenCalledWith '401: Error while updating'
+        expect(@cb).toHaveBeenCalledWith '401: Error while updating', undefined
 
         # Successful Request
         @jira.request.mostRecentCall.args[1] null, statusCode:200,
@@ -475,7 +475,7 @@ describe "Node Jira Tests", ->
         expect(@jira.request).toHaveBeenCalledWith options, jasmine.any(Function)
 
         @jira.request.mostRecentCall.args[1] null, statusCode:401
-        expect(@cb).toHaveBeenCalledWith '401: Error while updating'
+        expect(@cb).toHaveBeenCalledWith '401: Error while updating', undefined
 
         # Successful Request
         @jira.request.mostRecentCall.args[1] null, statusCode:204
@@ -495,10 +495,10 @@ describe "Node Jira Tests", ->
         expect(@jira.request).toHaveBeenCalledWith options, jasmine.any(Function)
 
         @jira.request.mostRecentCall.args[1] null, statusCode:401
-        expect(@cb).toHaveBeenCalledWith '401: Error while updating'
+        expect(@cb).toHaveBeenCalledWith '401: Error while updating', undefined
 
         @jira.request.mostRecentCall.args[1] null, statusCode:500
-        expect(@cb).toHaveBeenCalledWith '500: Error while retrieving list.'
+        expect(@cb).toHaveBeenCalledWith '500: Error while retrieving list.', undefined
 
         # Successful Request
         @jira.request.mostRecentCall.args[1] null, statusCode:200, "body"
@@ -523,7 +523,7 @@ describe "Node Jira Tests", ->
 
         @jira.request.mostRecentCall.args[1] null, statusCode:400,
             '{"body:"none"}'
-        expect(@cb).toHaveBeenCalledWith 'Invalid Fields: "{\\"body:\\"none\\"}"'
+        expect(@cb).toHaveBeenCalledWith 'Invalid Fields: "{\\"body:\\"none\\"}"', jasmine.any(String)
 
         # Successful Request
         @jira.request.mostRecentCall.args[1] null, statusCode:201
@@ -549,10 +549,10 @@ describe "Node Jira Tests", ->
         expect(@cb).toHaveBeenCalledWith 'Invalid Fields: "{\\"body:\\"none\\"}"'
 
         @jira.request.mostRecentCall.args[1] null, statusCode:403
-        expect(@cb).toHaveBeenCalledWith 'Insufficient Permissions'
+        expect(@cb).toHaveBeenCalledWith 'Insufficient Permissions', undefined
 
         @jira.request.mostRecentCall.args[1] null, statusCode:401
-        expect(@cb).toHaveBeenCalledWith '401: Error while updating'
+        expect(@cb).toHaveBeenCalledWith '401: Error while updating', undefined
 
         # Successful Request
         @jira.request.mostRecentCall.args[1] null, statusCode:201
@@ -578,10 +578,10 @@ describe "Node Jira Tests", ->
         expect(@cb).toHaveBeenCalledWith 'Invalid Fields: "{\\"body:\\"none\\"}"'
 
         @jira.request.mostRecentCall.args[1] null, statusCode:403
-        expect(@cb).toHaveBeenCalledWith 'Insufficient Permissions'
+        expect(@cb).toHaveBeenCalledWith 'Insufficient Permissions', undefined
 
         @jira.request.mostRecentCall.args[1] null, statusCode:401
-        expect(@cb).toHaveBeenCalledWith '401: Error while updating'
+        expect(@cb).toHaveBeenCalledWith '401: Error while updating', undefined
 
         # Successful Request
         @jira.request.mostRecentCall.args[1] null, statusCode:201
@@ -601,7 +601,7 @@ describe "Node Jira Tests", ->
         expect(@jira.request).toHaveBeenCalledWith options, jasmine.any(Function)
 
         @jira.request.mostRecentCall.args[1] null, statusCode:401
-        expect(@cb).toHaveBeenCalledWith '401: Error while retrieving issue types'
+        expect(@cb).toHaveBeenCalledWith '401: Error while retrieving issue types', undefined
 
         # Successful Request
         @jira.request.mostRecentCall.args[1] null, statusCode:200, "body"
@@ -621,7 +621,7 @@ describe "Node Jira Tests", ->
         expect(@jira.request).toHaveBeenCalledWith options, jasmine.any(Function)
 
         @jira.request.mostRecentCall.args[1] null, statusCode:500
-        expect(@cb).toHaveBeenCalledWith '500: Error while retrieving backlog'
+        expect(@cb).toHaveBeenCalledWith '500: Error while retrieving backlog', undefined
 
         # Successful Request
         @jira.request.mostRecentCall.args[1] null, statusCode:200, body: issues: ['test']


### PR DESCRIPTION
It'd be nice if node-jira returned the response body as well as the error even for errors as it makes finding bugs on projects that depend on it way easier.

I'm solving https://github.com/node-gh/gh-jira/issues/40 right now and it'd be really handy if we could access the error messages in a way like this, even to tell our users about what error happened so we can get better reports.

If you decide to merge these changes, please update the npm package as well :)
