### PR TITLE
Added updateVersion method

### DIFF
--- a/lib/jira.js
+++ b/lib/jira.js
@@ -702,6 +702,67 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         });
     };
 
+    // ## Update a version ##
+    // ### Takes ###
+    //
+    // *  version: an object of the new version
+    // *  callback: for when it's done
+    //
+    // ### Returns ###
+    //
+    // *  error: error text
+    // *  version: should be the same version you passed up
+    //
+    // [Jira Doc](https://docs.atlassian.com/jira/REST/latest/#d2e510)
+    //
+    /* {
+     *    "id": The ID of the version being updated. Required.
+     *    "description": "An excellent version",
+     *    "name": "New Version 1",
+     *    "archived": false,
+     *    "released": true,
+     *    "releaseDate": "2010-07-05",
+     *    "userReleaseDate": "5/Jul/2010",
+     *    "project": "PXA"
+     * }
+     */
+    this.updateVersion = function(version, callback) {
+        var options = {
+            rejectUnauthorized: this.strictSSL,
+            uri: this.makeUri('/version/'+version.id),
+            method: 'PUT',
+            followAllRedirects: true,
+            json: true,
+            body: version
+        };
+
+        this.doRequest(options, function(error, response, body) {
+
+            if (error) {
+                callback(error, null);
+                return;
+            }
+
+            if (response.statusCode === 404) {
+                callback('Version does not exist or the currently authenticated user does not have permission to view it');
+                return;
+            }
+
+            if (response.statusCode === 403) {
+                callback('The currently authenticated user does not have permission to edit the version');
+                return;
+            }
+
+            if (response.statusCode !== 200) {
+                callback(response.statusCode + ': Unable to connect to JIRA during updateVersion.');
+                return;
+            }
+
+            callback(null, body);
+
+        });
+    };
+
     // ## Pass a search query to Jira ##
     // ### Takes ###
     //


### PR DESCRIPTION
I added a method that can be used to update a Jira version, based on the ID.  I followed the documentation and error reporting that other methods used.  I added this as part of a GitHub-Jira synchronizer I'm writing and thought I'd share it.
