### PR TITLE
Replace @'s in usernames so the JQL query can be run

### DIFF
--- a/lib/jira.js
+++ b/lib/jira.js
@@ -900,6 +900,9 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
     // [Jira Doc](http://docs.atlassian.com/jira/REST/latest/#id296043)
     //
     this.getUsersIssues = function(username, open, callback) {
+        if (username.indexOf("@") > -1) {
+            username = username.replace("@", '\\u0040');
+        }
         var jql = "assignee = " + username;
         var openText = ' AND status in (Open, "In Progress", Reopened)';
         if (open) { jql += openText; }

--- a/spec/jira.spec.coffee
+++ b/spec/jira.spec.coffee
@@ -368,6 +368,15 @@ describe "Node Jira Tests", ->
         expect(@jira.searchJira).toHaveBeenCalledWith expected, {},
             jasmine.any(Function)
 
+    it "Properly Escapes @'s in Usernames", ->
+        spyOn @jira, 'searchJira'
+        expected = "assignee = email\\u0040example.com AND status in (Open, \"In Progress\",
+ Reopened)"
+
+        @jira.getUsersIssues 'email@example.com', true, @cb
+        expect(@jira.searchJira).toHaveBeenCalledWith expected, {},
+            jasmine.any(Function)
+
     it "Gets the sprint issues and information", ->
         options =
             rejectUnauthorized: true


### PR DESCRIPTION
Replace @'s with '\u0040' as per JQL instructions:

> "Error in the JQL Query: The character '@' is a reserved JQL character. You must enclose it in a string or use the escape '\u0040' instead. (line 1, character 15)"
