### PR TITLE
Call 'doRequest' method instead of calling Node's 'request' method.

### DIFF
--- a/lib/jira.js
+++ b/lib/jira.js
@@ -1723,7 +1723,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             json: true
         };
 
-        this.request(options, function(error, response, body) {
+        this.doRequest(options, function(error, response, body) {
 
             if (error) {
                 callback(error, null);


### PR DESCRIPTION
In getCurrentUser method, `request` method from `url` module is directly called. Instead we should call `doRequest` method that will prepare credentials needed for authentication.
