### PR TITLE
Fixing uncaught exception when response is empty.

### DIFF
--- a/lib/jira.js
+++ b/lib/jira.js
@@ -230,6 +230,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
 
             if (body === undefined) {
                 callback('Response body was undefined.');
+                return;
             }
 
             callback(null, JSON.parse(body));


### PR DESCRIPTION
If the response body is undefined it would call the callback but not return. The lib would then fail on line 235 trying to parse the "undefined" body.
