### PR TITLE
Must not remember cookies

### DIFF
--- a/lib/jira.js
+++ b/lib/jira.js
@@ -146,7 +146,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
     }
     this.strictSSL = strictSSL;
     // This is so we can fake during unit tests
-    this.request = require('request');
+    this.request = require('request').defaults({ jar: false });
     if (verbose !== true) { logger = { log: function() {} }; }
 
     // This is the same almost every time, refactored to make changing it


### PR DESCRIPTION
It allows to use different instances of JiraApi with different users' credentials
