### PR TITLE
Added visibility support for comments

### DIFF
--- a/lib/jira.js
+++ b/lib/jira.js
@@ -1442,13 +1442,21 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
     // *  issueId: Issue to add a comment to
     // *  comment: string containing comment
     // *  callback: for when it's done
+    // *  [visibility]: visibility of comment, optional
     //
     // ### Returns ###
     // *  error string
     // *  success string
     //
     // [Jira Doc](https://docs.atlassian.com/jira/REST/latest/#id108798)
-    this.addComment = function(issueId, comment, callback){
+    /**
+     * Visibility object format
+     * {
+     *   "type": "role",
+     *   "value": "Administrators"
+     * }
+     */
+    this.addComment = function(issueId, comment, callback, visibility){
         var options = {
             rejectUnauthorized: this.strictSSL,
             uri: this.makeUri('/issue/' + issueId + '/comment'),
@@ -1459,6 +1467,10 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             followAllRedirects: true,
             json: true
         };
+
+        if (visibility) {
+            options.body.visibility = visibility;
+        }
 
         this.doRequest(options, function(error, response, body) {
             if (error) {

--- a/spec/jira.spec.coffee
+++ b/spec/jira.spec.coffee
@@ -527,6 +527,10 @@ describe "Node Jira Tests", ->
               user: 'test'
               pass: 'test'
 
+        visibility =
+            type: "role"
+            value: "Administrators"
+
         @jira.addComment 1, 'aComment', @cb
         expect(@jira.request).toHaveBeenCalledWith options, jasmine.any(Function)
 
@@ -537,6 +541,13 @@ describe "Node Jira Tests", ->
         # Successful Request
         @jira.request.mostRecentCall.args[1] null, statusCode:201
         expect(@cb).toHaveBeenCalledWith null, "Success"
+
+        # Comments with predetermined level of visibility
+        @jira.request.reset()
+        @jira.addComment 1, "aComment", @cb, visibility
+        #extend options object
+        options.body.visibility = visibility
+        expect(@jira.request).toHaveBeenCalledWith options, jasmine.any(Function)
 
     it "Adds a worklog to a project", ->
         options =


### PR DESCRIPTION
Added optional parameter for backward compatibility. For future major releases "addComment" method design should be changed to `this.addComment = function(issueId, commentData, callback)`
