### PR TITLE
Add option base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ JiraApi options:
 *  `Jira API Version<string>`: Known to work with `2` and `2.0.alpha1`
 *  `verbose<bool>`: Log some info to the console, usually for debugging
 *  `strictSSL<bool>`: Set to false if you have self-signed certs or something non-trustworthy
+*  `oauth`: A dictionary of `consumer_key`, `consumer_secret`, `access_token` and `access_token_secret` to be used for OAuth authentication.
+*  `base<string>`: A base slug if your JIRA instance is not at the root of `host`
 
 ## Implemented APIs ##
 

--- a/lib/jira.js
+++ b/lib/jira.js
@@ -49,7 +49,8 @@
 // *  `Jira API Version<string>`: Known to work with `2` and `2.0.alpha1`
 // *  `verbose<bool>`: Log some info to the console, usually for debugging
 // *  `strictSSL<bool>`: Set to false if you have self-signed certs or something non-trustworthy
-// * `oauth`: A dictionary of `consumer_key`, `consumer_secret`, `access_token` and `access_token_secret` to be used for OAuth authentication.
+// *  `oauth`: A dictionary of `consumer_key`, `consumer_secret`, `access_token` and `access_token_secret` to be used for OAuth authentication.
+// *  `base`: Add base slug if your JIRA install is not at the root of the host
 //
 // ## Implemented APIs ##
 //
@@ -132,13 +133,14 @@ var url = require('url'),
     OAuth = require("oauth");
 
 
-var JiraApi = exports.JiraApi = function(protocol, host, port, username, password, apiVersion, verbose, strictSSL, oauth) {
+var JiraApi = exports.JiraApi = function(protocol, host, port, username, password, apiVersion, verbose, strictSSL, oauth, base) {
     this.protocol = protocol;
     this.host = host;
     this.port = port;
     this.username = username;
     this.password = password;
     this.apiVersion = apiVersion;
+    this.base = base;
     // Default strictSSL to true (previous behavior) but now allow it to be
     // modified
     if (strictSSL == null) {
@@ -155,6 +157,9 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         var basePath = 'rest/api/';
         if (altBase != null) {
             basePath = altBase;
+        }
+        if (this.base) {
+            basePath = this.base + '/' + basePath;
         }
 
         var apiVersion = this.apiVersion;


### PR DESCRIPTION
In my case, our JIRA instance is not at the root of the host it is on.
I add a new argument `base` (at the end for backward compatibility) that will prepend an additional slug to any API URI.