### PR TITLE
add 'expand' parameter to searchJira method and update documentation link

### DIFF
--- a/lib/jira.js
+++ b/lib/jira.js
@@ -860,7 +860,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
     // *  error: string if there's an error
     // *  issues: array of issues for the user
     //
-    // [Jira Doc](http://docs.atlassian.com/jira/REST/latest/#id333082)
+    // [Jira Doc](https://docs.atlassian.com/jira/REST/latest/#d2e4424)
     this.searchJira = function(searchString, optional, callback) {
         // backwards compatibility
         optional = optional || {};
@@ -878,7 +878,8 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
                 jql: searchString,
                 startAt: optional.startAt || 0,
                 maxResults: optional.maxResults || 50,
-                fields: optional.fields || ["summary", "status", "assignee", "description"]
+                fields: optional.fields || ["summary", "status", "assignee", "description"],
+                expand: optional.expand || ['schema', 'names']
             }
         };
 


### PR DESCRIPTION
In some situations, it's nice to be able to fetch more issue data than the search API returns by default. JIRA's REST API search method supports an expand parameter that allows one to request more detail for each issue, but this library didn't support it.

This adds that support.
