### PR TITLE
Fixing OAuth support as Atlassian provider only supports RSA-SHA1

### DIFF
--- a/lib/jira.js
+++ b/lib/jira.js
@@ -49,7 +49,7 @@
 // *  `Jira API Version<string>`: Known to work with `2` and `2.0.alpha1`
 // *  `verbose<bool>`: Log some info to the console, usually for debugging
 // *  `strictSSL<bool>`: Set to false if you have self-signed certs or something non-trustworthy
-// *  `oauth`: A dictionary of `consumer_key`, `consumer_secret`, `access_token` and `access_token_secret` to be used for OAuth authentication.
+// *  `oauth`: A dictionary of `consumer_key`, `consumer_secret`, `access_token` and `access_token_secret` to be used for OAuth authentication. Optional signature_method, but Atlassian uses RSA-SHA1.
 // *  `base`: Add base slug if your JIRA install is not at the root of the host
 //
 // ## Implemented APIs ##
@@ -129,8 +129,7 @@
 // *  _0.0.3 Added APIs and Docco documentation_
 // *  _0.0.2 Initial version_
 var url = require('url'),
-    logger = console,
-    OAuth = require("oauth");
+    logger = console;
 
 
 var JiraApi = exports.JiraApi = function(protocol, host, port, username, password, apiVersion, verbose, strictSSL, oauth, base) {
@@ -182,7 +181,8 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             consumer_key: oauth.consumer_key,
             consumer_secret: oauth.consumer_secret,
             token: oauth.access_token,
-            token_secret: oauth.access_token_secret
+            token_secret: oauth.access_token_secret,
+            signature_method: oauth.signature_method || 'RSA-SHA1'
           };
         } else if(this.username && this.password) {
           options.auth = {
@@ -1268,7 +1268,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
 
         });
     };
-    
+
     // ## Add component to Jira ##
     // ### Takes ###
     //
@@ -1289,29 +1289,29 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             json: true,
             body: component
         };
-        
+
         this.doRequest(options, function (error, response, body) {
-            
+
             if (error) {
                 callback(error, null);
                 return;
             }
-            
+
             if (response.statusCode === 400) {
                 callback(body);
                 return;
             }
-            
+
             if ((response.statusCode !== 200) && (response.statusCode !== 201)) {
                 callback(response.statusCode + ': Unable to connect to JIRA during search.');
                 return;
             }
-            
+
             callback(null, body);
 
         });
     };
-    
+
     // ## Delete component to Jira ##
     // ### Takes ###
     //
@@ -1331,19 +1331,19 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             followAllRedirects: true,
             json: true
         };
-        
+
         this.doRequest(options, function (error, response) {
-            
+
             if (error) {
                 callback(error, null);
                 return;
             }
-            
+
             if (response.statusCode === 204) {
                 callback(null, "Success");
                 return;
             }
-            
+
             callback(response.statusCode + ': Error while deleting');
 
         });
@@ -1656,7 +1656,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
                 callback("Invalid Fields: " + JSON.stringify(body));
                 return;
             };
-            
+
             callback(response.statusCode + ': Error while adding comment');
         });
     };

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     }
   ],
   "dependencies": {
-    "request": "<2.16.0",
-    "oauth": "^0.9.11"
+    "request": "^2.69.0"
   },
   "scripts": {
     "test": "grunt test"


### PR DESCRIPTION
Atlassian OAuth only provides RSA-SHA1 (at least in the cloud version).
This requires a new version of request module, the old version doesn't support RSA-SHA1.

But seems everything else is still working.

Also oAUTH module is not needed, so removed it.
