### PR TITLE
Add runBackup function

### DIFF
--- a/lib/jira.js
+++ b/lib/jira.js
@@ -1268,7 +1268,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
 
         });
     };
-    
+
     // ## Add component to Jira ##
     // ### Takes ###
     //
@@ -1289,29 +1289,29 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             json: true,
             body: component
         };
-        
+
         this.doRequest(options, function (error, response, body) {
-            
+
             if (error) {
                 callback(error, null);
                 return;
             }
-            
+
             if (response.statusCode === 400) {
                 callback(body);
                 return;
             }
-            
+
             if ((response.statusCode !== 200) && (response.statusCode !== 201)) {
                 callback(response.statusCode + ': Unable to connect to JIRA during search.');
                 return;
             }
-            
+
             callback(null, body);
 
         });
     };
-    
+
     // ## Delete component to Jira ##
     // ### Takes ###
     //
@@ -1331,19 +1331,19 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             followAllRedirects: true,
             json: true
         };
-        
+
         this.doRequest(options, function (error, response) {
-            
+
             if (error) {
                 callback(error, null);
                 return;
             }
-            
+
             if (response.statusCode === 204) {
                 callback(null, "Success");
                 return;
             }
-            
+
             callback(response.statusCode + ': Error while deleting');
 
         });
@@ -1656,7 +1656,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
                 callback("Invalid Fields: " + JSON.stringify(body));
                 return;
             };
-            
+
             callback(response.statusCode + ': Error while adding comment');
         });
     };
@@ -2138,5 +2138,91 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             callback(response.statusCode + ': Error while retrieving backlog');
         });
     };
+
+    /**
+     * Creates a new backup of JIRA and returns its URI
+     * User needs to be in the administrator group to run backups and access webdav
+     *
+     * @param callback
+     */
+    this.runBackup = function(callback) {
+
+        //build today's backup file URI
+        var today = new Date().toISOString().replace(/T.+/, '').replace(/-/g,'');
+        var todayBackupUri = this.makeUri('webdav/backupmanager/JIRA-backup-'+today+'.zip', '', '');
+        var runBackupUri = this.makeUri('/runbackup', 'rest/obm/', '1.0');
+
+        //prepare a HEAD request to check if today's backup exists
+        var optionsTodayBackup = {
+          uri: todayBackupUri,
+          method: 'HEAD',
+          encoding: null,
+          json:false
+        };
+
+        this.doRequest(optionsTodayBackup, function(error, response) {
+          if (error) {
+              callback(error, reponse);
+              return;
+          }
+
+          if (response.statusCode === 404) {
+            //today's backup does not exists - we need to run the backup
+             options = {
+                rejectUnauthorized: this.strictSSL,
+                uri: runBackupUri,
+                method: 'POST',
+                followAllRedirects: true,
+                json:true,
+                body: {
+                  cbAttachments: true
+                }
+              };
+
+              this.doRequest(options, function(error, response) {
+
+                if (error) {
+                    callback(error, response);
+                    return;
+                }
+
+                if (response.statusCode === 404) {
+                  callback('Invalid URL: '+options.uri, response);
+                  return;
+                }
+
+                if (response.statusCode !== 200) {
+                  //if another backup has been made less than 48h ago in JIRA cloud
+                  //a 500 is returned here with an explicit body message
+                  callback(response.statusCode + ': Unable to run backup.', response);
+                  return;
+                } else {
+                  //check that the backup does exist now
+                  this.doRequest(optionsTodayBackup, function(error, response) {
+                    if (error, reponse) {
+                        callback(error);
+                        return;
+                    }
+
+                    if (response.statusCode === 200) {
+                      callback(null, todayBackupUri);
+                      return;
+                    } else {
+                      callback('Unable to download file: '+todayBackupUri, reponse);
+                      return;
+                    }
+                }.bind(this));
+              }
+          });
+        } else {
+          if (response.statusCode === 200) {
+            return callback(null, todayBackupUri);
+          } else {
+            callback(options.statusCode+' error received', response);
+            return;
+          }
+        }
+      }.bind(this));
+    }
 
 }).call(JiraApi.prototype);

--- a/lib/jira.js
+++ b/lib/jira.js
@@ -1268,7 +1268,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
 
         });
     };
-
+    
     // ## Add component to Jira ##
     // ### Takes ###
     //
@@ -1289,29 +1289,29 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             json: true,
             body: component
         };
-
+        
         this.doRequest(options, function (error, response, body) {
-
+            
             if (error) {
                 callback(error, null);
                 return;
             }
-
+            
             if (response.statusCode === 400) {
                 callback(body);
                 return;
             }
-
+            
             if ((response.statusCode !== 200) && (response.statusCode !== 201)) {
                 callback(response.statusCode + ': Unable to connect to JIRA during search.');
                 return;
             }
-
+            
             callback(null, body);
 
         });
     };
-
+    
     // ## Delete component to Jira ##
     // ### Takes ###
     //
@@ -1331,19 +1331,19 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
             followAllRedirects: true,
             json: true
         };
-
+        
         this.doRequest(options, function (error, response) {
-
+            
             if (error) {
                 callback(error, null);
                 return;
             }
-
+            
             if (response.statusCode === 204) {
                 callback(null, "Success");
                 return;
             }
-
+            
             callback(response.statusCode + ': Error while deleting');
 
         });
@@ -1656,7 +1656,7 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
                 callback("Invalid Fields: " + JSON.stringify(body));
                 return;
             };
-
+            
             callback(response.statusCode + ': Error while adding comment');
         });
     };


### PR DESCRIPTION
This is a function I created to run JIRA backups from an AWS lambda function (it could also be used from any node app obviously).

All it does, is checking in Webdav if a backup for today exists (HEAD request), returns it URI if it's the case and try to run the runBackup API function (POST) in JIRA to generate if otherwise and returns the new backup URI if successful.
