### PR TITLE
Upgrade request version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     }
   ],
   "dependencies": {
-    "request": "<2.16.0",
-    "oauth": "^0.9.11"
+    "oauth": "^0.9.11",
+    "request": "^2.79.0"
   },
   "scripts": {
     "test": "grunt test"


### PR DESCRIPTION
Closes #141 .

This PR upgrades the `request` package to latest version, which is `2.79.0` as of the time of this PR.

I tried running tests, but 2 tests fail, even on the master branch. 