### PR TITLE
 Allow query filters in findIssue request

### DIFF
--- a/lib/jira.js
+++ b/lib/jira.js
@@ -200,6 +200,9 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
     // ### Takes ###
     //
     // *  issueNumber: the issueNumber to find
+    // *  optional: object containing any optional query string arguments as specified in the API.
+    //              For backwards compatibility, this input is optional. Therefore, this proc can be
+    //              called with findIssue(issuenumber, callback).
     // *  callback: for when it's done
     //
     // ### Returns ###
@@ -208,13 +211,24 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
     // *  issue: an object of the issue
     //
     // [Jira Doc](http://docs.atlassian.com/jira/REST/latest/#id290709)
-    this.findIssue = function(issueNumber, callback) {
+    this.findIssue = function(issueNumber, optional, callback) {
 
         var options = {
             rejectUnauthorized: this.strictSSL,
             uri: this.makeUri('/issue/' + issueNumber),
             method: 'GET'
         };
+
+        // For backwards compatibility, allow "optional" to have not been passed in
+        // i.e. there are only two arguments to the function - issueNumber and callback
+        if (arguments.length == 2) {
+          callback = optional
+          optional = null
+        }
+
+        if (optional != null) {
+            options.qs = optional
+	}
 
         this.doRequest(options, function(error, response, body) {
 


### PR DESCRIPTION
Create a new argument in the findIssue functional for query string args allowed by the API. This remains backwards compatible so leaving out this arg when calling findIssue will revert to the old functionality.