### PR TITLE
Noticed missing documentation in search

### DIFF
--- a/lib/jira.js
+++ b/lib/jira.js
@@ -858,6 +858,9 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
     //     *  "status"
     //     *  "assignee"
     //     *  "description"
+    //   *  expand: optional array of desired expand nodes, defaults when null:
+    //     *  "schema"
+    //     *  "names"
     // *  callback: for when it's done
     //
     // ### Returns ###


### PR DESCRIPTION
Check documentation: 

https://docs.atlassian.com/software/jira/docs/api/REST/7.6.1/#api/2/search

Seems that the expand field is being triggered by the module, and even has defaults. Updated the code comment to reflect this, consistent with other params in the comments